### PR TITLE
[feature/get-news-list-by-query] 검색어에 해당하는 뉴스 기사 데이터 반환하도록 로직 수정

### DIFF
--- a/src/main/java/com/newz/api/news/keywordnews/controller/KeywordNewsController.java
+++ b/src/main/java/com/newz/api/news/keywordnews/controller/KeywordNewsController.java
@@ -1,9 +1,8 @@
 package com.newz.api.news.keywordnews.controller;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.newz.api.news.keywordnews.model.NewsListResponse;
+import com.newz.api.news.keywordnews.service.KeywordNewsService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,32 +14,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/news")
 public class KeywordNewsController {
 
+  @Autowired
+  private KeywordNewsService keywordNewsService;
+
   @GetMapping("/list")
-  public ResponseEntity<List<Map<String, Object>>> getNewsListByQuery(
+  public ResponseEntity<NewsListResponse> getNewsListByQuery(
       @RequestParam("query") String query,
       @RequestParam(value = "page", required = false, defaultValue = "1") int page,
       @RequestParam(value = "limit", required = false, defaultValue = "3") int limit) {
-    List<Map<String, Object>> result = new ArrayList<>();
-
-    Map<String, Object> item1 = new HashMap<>();
-    item1.put("title", "커피빈, 제품 가격 인상");
-    item1.put("content", "커피 전문점 '커피빈'은 3일부터 우유가 포함된 음료의 가격을 200원씩 인상하며 카페라떼(s)를 기존 5600원에서 5800원에, 바닐라라떼(s)는 6100원에서 6300원에 구매할 수 있다.");
-    item1.put("link", "https://n.news.naver.com/mnews/article/055/0001025795?sid=102");
-    result.add(item1);
-
-    Map<String, Object> item2 = new HashMap<>();
-    item2.put("title", "\"편의점도 모닝 세트 판다\"…CU, GET 커피 세트 할인 행사");
-    item2.put("content", "CU가 새해 리오프닝을 맞아 아침밥 시장을 공략하기 위해 GET 커피를 중심으로 모닝 세트 할인 등 다양한 행사를 펼친다고 2일 밝혔다.");
-    item2.put("link", "https://n.news.naver.com/mnews/article/032/0003197157?sid=102");
-    result.add(item2);
-
-    Map<String, Object> item3 = new HashMap<>();
-    item3.put("title", "대전신세계, 엑스포타워 스페셜티 커피 전문점 '폴 바셋' 오픈");
-    item3.put("link", "https://n.news.naver.com/mnews/article/082/0001192142?sid=102");
-    item3.put("content", "3일 대전신세계는 대전 최고층 건물에서 즐기는 시원한 전망과 정통 이탈리안 피자 등을 함께 즐길 수 있는 스페셜티 커피 전문점 '폴 바셋' 대전엑스포 스카이점이 오픈한다고 밝혔다.");
-    result.add(item3);
-
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    return new ResponseEntity<>(keywordNewsService.getNewsListByQuery(query, page, limit), HttpStatus.OK);
   }
 
 }

--- a/src/main/java/com/newz/api/news/keywordnews/controller/KeywordNewsController.java
+++ b/src/main/java/com/newz/api/news/keywordnews/controller/KeywordNewsController.java
@@ -2,6 +2,11 @@ package com.newz.api.news.keywordnews.controller;
 
 import com.newz.api.news.keywordnews.model.NewsListResponse;
 import com.newz.api.news.keywordnews.service.KeywordNewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +22,19 @@ public class KeywordNewsController {
   @Autowired
   private KeywordNewsService keywordNewsService;
 
+  @Operation(summary = "검색어(키워드)에 해당하는 뉴스 기사 데이터 반환")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "limit 값 만큼 검색어에 맞는 뉴스 기사 제목/요약내용/원문링크 데이터 반환",
+          content = {
+              @Content(
+                  mediaType = "application/json",
+                  schema = @Schema(implementation = NewsListResponse.class)
+              )
+          }
+      )
+  })
   @GetMapping("/list")
   public ResponseEntity<NewsListResponse> getNewsListByQuery(
       @RequestParam("query") String query,

--- a/src/main/java/com/newz/api/news/keywordnews/model/NewsListModel.java
+++ b/src/main/java/com/newz/api/news/keywordnews/model/NewsListModel.java
@@ -2,7 +2,6 @@ package com.newz.api.news.keywordnews.model;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 @Builder

--- a/src/main/java/com/newz/api/news/keywordnews/model/NewsListModel.java
+++ b/src/main/java/com/newz/api/news/keywordnews/model/NewsListModel.java
@@ -1,0 +1,15 @@
+package com.newz.api.news.keywordnews.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Builder
+public class NewsListModel {
+
+  private String title;
+  private String content;
+  private String link;
+
+}

--- a/src/main/java/com/newz/api/news/keywordnews/model/NewsListResponse.java
+++ b/src/main/java/com/newz/api/news/keywordnews/model/NewsListResponse.java
@@ -1,0 +1,15 @@
+package com.newz.api.news.keywordnews.model;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NewsListResponse {
+
+  private List<NewsListModel> news;
+  private long total;
+  private int page;
+
+}

--- a/src/main/java/com/newz/api/news/keywordnews/service/KeywordNewsService.java
+++ b/src/main/java/com/newz/api/news/keywordnews/service/KeywordNewsService.java
@@ -1,10 +1,55 @@
 package com.newz.api.news.keywordnews.service;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.newz.api.news.keywordnews.model.NewsListModel;
+import com.newz.api.news.keywordnews.model.NewsListResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @AllArgsConstructor
 public class KeywordNewsService {
+
+  private final Gson gson = new Gson();
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  private static final String NEWS_CRAWLER_API_URL = "http://localhost:5000/news/list";
+
+  public NewsListResponse getNewsListByQuery(String query, int page, int limit) {
+    StringBuilder stringBuilder = new StringBuilder(NEWS_CRAWLER_API_URL);
+    stringBuilder.append("?query=");
+    stringBuilder.append(query);
+    stringBuilder.append("&page=");
+    stringBuilder.append(page);
+    stringBuilder.append("&limit=");
+    stringBuilder.append(limit);
+
+    String requestUrl = stringBuilder.toString();
+
+    String response = restTemplate.getForObject(requestUrl, String.class);
+    Map<String, Object> parsedData = gson.fromJson(response, new TypeToken<Map<String, Object>>(){}.getType());
+
+    long total = (long) Double.parseDouble(parsedData.get("total").toString());
+    List<Map<String, Object>> newsData = (List<Map<String, Object>>) parsedData.get("news");
+
+    List<NewsListModel> newsDataResponse = newsData.stream()
+        .map(news -> NewsListModel.builder()
+            .title(news.get("title").toString())
+            .content(news.get("content").toString())
+            .link(news.get("link").toString())
+            .build())
+        .collect(Collectors.toList());
+
+    return NewsListResponse.builder()
+        .news(newsDataResponse)
+        .total(total)
+        .page(page)
+        .build();
+  }
 
 }


### PR DESCRIPTION
mock data를 리턴하던 /api/news/list 엔드포인트 로직을, 파이썬 서버에 요청해 입력받은 검색어에 해당하는 뉴스 기사를 가져와 반환해주도록 수정했습니다 :)