### PR TITLE
[feat/insert-user-keywords] 선택한 키워드 저장 API 추가

### DIFF
--- a/src/main/java/com/newz/api/NewzApiApplication.java
+++ b/src/main/java/com/newz/api/NewzApiApplication.java
@@ -6,6 +6,9 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @OpenAPIDefinition(
 	info = @Info(
@@ -24,6 +27,16 @@ public class NewzApiApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(NewzApiApplication.class, args);
+	}
+
+	@Bean
+	public WebMvcConfigurer corsConfigurer() {
+		return new WebMvcConfigurer() {
+			@Override
+			public void addCorsMappings(CorsRegistry registry) {
+				registry.addMapping("/api/**").allowedOrigins("*");
+			}
+		};
 	}
 
 }

--- a/src/main/java/com/newz/api/common/exception/ErrorResponse.java
+++ b/src/main/java/com/newz/api/common/exception/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.newz.api.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+  private String message;
+
+}

--- a/src/main/java/com/newz/api/common/exception/NewzCommonException.java
+++ b/src/main/java/com/newz/api/common/exception/NewzCommonException.java
@@ -1,0 +1,16 @@
+package com.newz.api.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NewzCommonException extends RuntimeException {
+
+  private final HttpStatus httpStatus;
+
+  public NewzCommonException(HttpStatus httpStatus, String message) {
+    super(message);
+    this.httpStatus = httpStatus;
+  }
+
+}

--- a/src/main/java/com/newz/api/common/exception/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/com/newz/api/common/exception/RestResponseEntityExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.newz.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class RestResponseEntityExceptionHandler {
+
+  @ExceptionHandler(value = {Exception.class})
+  protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    ErrorResponse response = ErrorResponse.builder()
+        .message(e.getMessage())
+        .build();
+
+    return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(value = {NewzCommonException.class})
+  protected ResponseEntity<ErrorResponse> handleNewzCommonException(NewzCommonException e) {
+    ErrorResponse response = ErrorResponse.builder()
+        .message(e.getMessage())
+        .build();
+
+    return new ResponseEntity<>(response, e.getHttpStatus());
+  }
+
+}

--- a/src/main/java/com/newz/api/user/controller/UserController.java
+++ b/src/main/java/com/newz/api/user/controller/UserController.java
@@ -1,11 +1,13 @@
 package com.newz.api.user.controller;
 
 import com.newz.api.user.model.BookmarkAddRequest;
+import com.newz.api.user.model.UserKeywordSetRequest;
 import com.newz.api.user.service.UserService;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -45,7 +47,9 @@ public class UserController {
   }
 
   @PostMapping("/keyword")
-  public ResponseEntity<List<Map<String, Object>>> setUserKeyword(@RequestBody List<String> keywords) {
+  public ResponseEntity<List<Map<String, Object>>> setUserKeyword(@RequestBody @Valid UserKeywordSetRequest request)
+      throws Exception {
+    userService.setUserKeyword(request);
     return new ResponseEntity<>(HttpStatus.OK);
   }
 

--- a/src/main/java/com/newz/api/user/model/UserKeywordSetRequest.java
+++ b/src/main/java/com/newz/api/user/model/UserKeywordSetRequest.java
@@ -1,0 +1,19 @@
+package com.newz.api.user.model;
+
+import java.util.List;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserKeywordSetRequest {
+
+  @Min(value = 0, message = "'userId' 파라미터는 필수입니다.")
+  private int userId;
+
+  @NotEmpty(message = "'keywords' 파라미터는 필수입니다.")
+  private List<String> keywords;
+
+}

--- a/src/main/java/com/newz/api/user/repository/UserMapper.xml
+++ b/src/main/java/com/newz/api/user/repository/UserMapper.xml
@@ -8,4 +8,18 @@
     FROM user
     WHERE id = #{userId}
   </select>
+
+  <select id="getSavedKeywordTotalCountByUserId" resultType="int">
+    SELECT count(*)
+    FROM user_keyword
+    WHERE user_id = #{userId}
+  </select>
+
+  <insert id="insertUserKeywords" parameterType="com.newz.api.user.vo.UserKeywordVo">
+    INSERT IGNORE INTO user_keyword(user_id, keyword)
+    VALUES
+    <foreach collection="keywords" item="keyword" open="(" close=")" separator="), (">
+      #{keyword.userId}, #{keyword.keyword}
+    </foreach>
+  </insert>
 </mapper>

--- a/src/main/java/com/newz/api/user/repository/UserRepository.java
+++ b/src/main/java/com/newz/api/user/repository/UserRepository.java
@@ -1,11 +1,17 @@
 package com.newz.api.user.repository;
 
+import com.newz.api.user.vo.UserKeywordVo;
 import com.newz.api.user.vo.UserVo;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface UserRepository {
 
   UserVo getUserInformationByUserId(int userId);
+
+  int getSavedKeywordTotalCountByUserId(int userId);
+
+  int insertUserKeywords(List<UserKeywordVo> keywords);
 
 }

--- a/src/main/java/com/newz/api/user/service/UserService.java
+++ b/src/main/java/com/newz/api/user/service/UserService.java
@@ -1,10 +1,16 @@
 package com.newz.api.user.service;
 
+import com.newz.api.common.exception.NewzCommonException;
+import com.newz.api.user.model.UserKeywordSetRequest;
 import com.newz.api.user.repository.UserRepository;
+import com.newz.api.user.vo.UserKeywordVo;
 import com.newz.api.user.vo.UserVo;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,6 +32,26 @@ public class UserService {
     result.put("email", user.getEmail());
 
     return result;
+  }
+
+  public void setUserKeyword(UserKeywordSetRequest request) throws Exception {
+    int savedKeywordTotalCount = userRepository.getSavedKeywordTotalCountByUserId(request.getUserId());
+    if(savedKeywordTotalCount == 9 || savedKeywordTotalCount + request.getKeywords().size() > 9) {
+      throw new NewzCommonException(
+          HttpStatus.CONFLICT,
+          "키워드는 총 9개까지 저장 가능합니다. "
+              + "현재 저장된 키워드는 " + savedKeywordTotalCount+ "개, "
+              + "저장하려는 키워드는 " + request.getKeywords().size() + "개 입니다.");
+    }
+
+    List<UserKeywordVo> keywords = request.getKeywords().stream()
+        .map(keyword -> UserKeywordVo.builder()
+            .userId(request.getUserId())
+            .keyword(keyword)
+            .build())
+        .collect(Collectors.toList());
+
+    userRepository.insertUserKeywords(keywords);
   }
 
 }

--- a/src/main/java/com/newz/api/user/vo/UserKeywordVo.java
+++ b/src/main/java/com/newz/api/user/vo/UserKeywordVo.java
@@ -1,0 +1,16 @@
+package com.newz.api.user.vo;
+
+import java.time.ZonedDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserKeywordVo {
+
+  private int id;
+  private ZonedDateTime createDtm;
+  private int userId;
+  private String keyword;
+
+}


### PR DESCRIPTION
- 전달받은 키워드 DB에 저장하는 로직 추가
- 공통 에러 처리부 추가
- 모든 호스트 허용하도록 CORS 설정 추가